### PR TITLE
INTERNAL: clean unused env variable `SERVICE_API_KEY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ To run the `configure-events` script, ensure that your project configuration (`.
 
 Additionally, the script uses the following environment variables:
 
-- `SERVICE_API_KEY`: The API key for the service.
 - `AIO_runtime_namespace`: The Adobe I/O Runtime namespace used as suffix for the Adobe I/O Events provider label.
 - `AIO_EVENTS_PROVIDERMETADATA_TO_PROVIDER_MAPPING`: (Optional) Existing provider metadata to provider mapping.
 

--- a/payment-methods.yaml
+++ b/payment-methods.yaml
@@ -6,7 +6,7 @@ methods:
       backend_integration_url: http://oope-payment-method.pay/event
       stores:
         - default
-      order_status: pending
+      order_status: processing
       countries:
         - US
       currencies:

--- a/scripts/configure-events.js
+++ b/scripts/configure-events.js
@@ -59,12 +59,6 @@ async function main() {
     return;
   }
 
-  const clientId = process.env.SERVICE_API_KEY;
-  if (!clientId) {
-    logger.warn('Cannot find SERVICE_API_KEY environment variable, event providers reconciliation will be skipped');
-    return;
-  }
-
   const { imsOrgId, apiKey, accessToken } = await resolveCredentials(process.env);
 
   logger.info(`Event providers label will be suffixed with "<label> - ${process.env.AIO_runtime_namespace}"`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `SERVICE_API_KEY`/ clientId is not used in `configure-events` script.
- Change default order_status of OOPE payment methods to `processing` which is the same as README.md.