### PR TITLE
CEXT-4530: get env variables from params not payload

### DIFF
--- a/actions/validate-payment/index.js
+++ b/actions/validate-payment/index.js
@@ -39,7 +39,7 @@ async function main(params) {
 
     logger.info(`Payment method ${paymentMethod} with additional info.`, paymentInfo);
 
-    const supportedPaymentMethods = JSON.parse(payload.COMMERCE_PAYMENT_METHOD_CODES);
+    const supportedPaymentMethods = JSON.parse(params.COMMERCE_PAYMENT_METHOD_CODES);
     if (!supportedPaymentMethods.includes(paymentMethod)) {
       // The validation of this payment method is not implemented by this action, ideally the webhook subscription
       // has to be constrained to the payment method code implemented by this app so this should never happen.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- After https://github.com/adobe/commerce-checkout-starter-kit/pull/26, the environment variables exist in params but not the payload, and it causes NPE.
- Retrieve env variables from params.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
