### PR TITLE
CEXT-4634: revert to use the renamed parameters in validate-payment

### DIFF
--- a/actions/validate-payment/index.js
+++ b/actions/validate-payment/index.js
@@ -35,7 +35,7 @@ async function main(params) {
       payload = JSON.parse(atob(params.__ow_body));
     }
 
-    const { additional_information: paymentInfo, method: paymentMethod } = payload.data.order.payment;
+    const { payment_method: paymentMethod, payment_additional_information: paymentInfo } = payload;
 
     logger.info(`Payment method ${paymentMethod} with additional info.`, paymentInfo);
 

--- a/actions/validate-payment/index.js
+++ b/actions/validate-payment/index.js
@@ -29,13 +29,10 @@ async function main(params) {
       return webhookErrorResponse(`Failed to verify the webhook signature: ${error}`);
     }
 
-    let payload = params;
-    if (params.__ow_body) {
-      // in the case when "raw-http: true" the body needs to be decoded and converted to JSON
-      payload = JSON.parse(atob(params.__ow_body));
-    }
+    // in the case when "raw-http: true" the body needs to be decoded and converted to JSON
+    const body = JSON.parse(atob(params.__ow_body));
 
-    const { payment_method: paymentMethod, payment_additional_information: paymentInfo } = payload;
+    const { payment_method: paymentMethod, payment_additional_information: paymentInfo } = body;
 
     logger.info(`Payment method ${paymentMethod} with additional info.`, paymentInfo);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- https://github.com/adobe/commerce-checkout-starter-kit/pull/26 introduced to use the original parameter than renamed accidently.
- However, this breaks the contract in Checkout Starter Kit to suggest using field name `payment_method`, `payment_additional_information`: https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/use-cases/#validate-payment-info. I decide to revert the code as `observer.sales_order_place_before` has a huge payload, and we don't need the full parameters for validating payment. 
- A PR to add missing PaaS docs in Checkout Starter Kit: https://github.com/AdobeDocs/commerce-extensibility/pull/369

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
