### PR TITLE
Sync oauth credentials

### DIFF
--- a/app.config.yaml
+++ b/app.config.yaml
@@ -1,4 +1,6 @@
 application:
+  hooks:
+    pre-app-build: ./hooks/pre-app-build.js
   actions: actions
   runtimeManifest:
     packages:

--- a/hooks/pre-app-build.js
+++ b/hooks/pre-app-build.js
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Core } = require('@adobe/aio-sdk');
+const logger = Core.Logger('hooks/pre-app-build', { level: process.env.LOG_LEVEL || 'info' });
+
+module.exports = () => {
+  require('../scripts/sync-oauth-credentials').main();
+  logger.info('Done');
+};

--- a/lib/env.js
+++ b/lib/env.js
@@ -46,4 +46,12 @@ function replaceEnvVar(filePath, key, value) {
   fs.writeFileSync(envPath, updatedLines.join('\n'), 'utf8');
 }
 
-module.exports = { replaceEnvVar };
+/**
+ * @returns {string} The path to the .env file.
+ */
+function resolveEnvPath() {
+  const envPath = process.env.INIT_CWD ? `${process.env.INIT_CWD}/.env` : '.env';
+  return path.resolve(envPath);
+}
+
+module.exports = { replaceEnvVar, resolveEnvPath };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "create-payment-methods": "node -e \"require('./scripts/create-payment-methods').main('payment-methods.yaml')\"",
     "create-tax-integrations": "node -e \"require('./scripts/create-tax-integrations').main('tax-integrations.yaml')\"",
     "create-shipping-carriers": "node -e \"require('./scripts/create-shipping-carriers').main('shipping-carriers.yaml')\"",
-    "get-shipping-carriers": "node -e \"require('./scripts/get-shipping-carriers').main()\""
+    "get-shipping-carriers": "node -e \"require('./scripts/get-shipping-carriers').main()\"",
+    "sync-oauth-credentials": "node -e \"require('./scripts/sync-oauth-credentials').main()\""
   },
   "engines": {
     "node": ">=22"

--- a/scripts/sync-oauth-credentials.js
+++ b/scripts/sync-oauth-credentials.js
@@ -1,0 +1,107 @@
+const fs = require('fs');
+const { Core } = require('@adobe/aio-sdk');
+const { replaceEnvVar, resolveEnvPath } = require('../lib/env');
+const dotenv = require('dotenv');
+
+const keyMap = {
+  client__id: 'OAUTH_CLIENT_ID',
+  client__secrets: 'OAUTH_CLIENT_SECRETS',
+  technical__account__email: 'OAUTH_TECHNICAL_ACCOUNT_EMAIL',
+  technical__account__id: 'OAUTH_TECHNICAL_ACCOUNT_ID',
+  scopes: 'OAUTH_SCOPES',
+  ims__org__id: 'OAUTH_IMS_ORG_ID',
+};
+
+const logger = Core.Logger('scripts/sync-oauth-credentials', { level: process.env.LOG_LEVEL || 'info' });
+
+/**
+ * Syncs OAUTH environment variables from AIO_ims_contexts_* variables in the .env file.
+ */
+function main() {
+  try {
+    logger.debug('Sync OAUTH env vars from AIO_ims_contexts_* vars in .env file');
+    const envPath = resolveEnvPath();
+    const envVars = dotenv.parse(fs.readFileSync(envPath, 'utf8'));
+    const imsContextEnvVars = parseImsContextEnvVars(envVars);
+    if (imsContextEnvVars.length === 0) {
+      logger.warn('No AIO_ims_contexts_* environment variables found in .env file');
+      return;
+    }
+
+    imsContextEnvVars.forEach(({ credential, key, value }) => {
+      const oauthKey = keyMap[key];
+      if (!oauthKey) {
+        logger.warn(`No mapping found for key: ${key}`);
+        return;
+      }
+
+      if (!envVars[oauthKey]) {
+        replaceEnvVar(envPath, oauthKey, value);
+        logger.info(`Added ${oauthKey} with value from AIO_ims_contexts_${credential}_${key}`);
+      } else if (envVars[oauthKey] !== value) {
+        replaceEnvVar(envPath, oauthKey, value);
+        logger.info(`Replaced ${oauthKey} with value from AIO_ims_contexts_${credential}_${key}`);
+      }
+      logger.debug(`${oauthKey} is in sync with AIO_ims_contexts_${credential}_${key}`);
+    });
+
+    logger.info('OAUTH env vars synced successfully');
+  } catch (e) {
+    logger.error('Failed to sync OAUTH env vars', e);
+  }
+}
+
+/**
+ * Parses the environment variables to find those that start with 'AIO_ims_contexts_'.
+ * @param {object} envVars the environment variables object
+ * @returns {Array} an array of objects containing the credential, key and value from the AIO_ims_contexts_* variables
+ */
+function parseImsContextEnvVars(envVars) {
+  return Object.entries(envVars)
+    .filter(([key]) => key.startsWith('AIO_ims_contexts_'))
+    .map(([key, value]) => ({
+      ...parseAioImsContextKey(key),
+      value,
+    }));
+}
+
+/**
+ * Parses the AIO_ims_contexts_* key to extract the credential and key.
+ * @param {string} imsKey the environment variable key that starts with 'AIO_ims_contexts_'
+ * @returns {object} an object containing the credential and key extracted from the imsKey
+ */
+function parseAioImsContextKey(imsKey) {
+  const str = imsKey.replace('AIO_ims_contexts_', '');
+  const [credential, key] = splitBySingleChar(str, '_');
+  return { credential, key };
+}
+
+/**
+ * Splits a string by a single character, ensuring that the character is not preceded or followed by the same character.
+ * @param {string} str the string to split
+ * @param {string} char the character to split by
+ * @returns {Array} an array of strings split by the specified character
+ */
+function splitBySingleChar(str, char) {
+  const result = [];
+  let current = '';
+  let i = 0;
+  while (i < str.length) {
+    if (
+      str[i] === char &&
+      (i === 0 || str[i - 1] !== char) && // not preceded by underscore
+      (i === str.length - 1 || str[i + 1] !== char) // not followed by underscore
+    ) {
+      result.push(current);
+      current = '';
+      i++; // skip the underscore
+    } else {
+      current += str[i];
+      i++;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+module.exports = { main };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Automates the synchronization of the OAUTH credentials by adding a pre-deploy-hook, from the envvars `AIO_ims_contexts_{credential}_{key}={value}` added when starting the project to `OAUTH_{key}={value}` injected into runtime actions.

Therefore, actions requiring IMS token generation should inject as params the following envvars:
```
OAUTH_CLIENT_ID
OAUTH_CLIENT_SECRETS
OAUTH_TECHNICAL_ACCOUNT_EMAIL
OAUTH_TECHNICAL_ACCOUNT_ID
OAUTH_SCOPES
OAUTH_IMS_ORG_ID
```
Token can be retrieved using `getAdobeAccessToken(params)` function, see https://github.com/adobe/commerce-checkout-starter-kit/blob/main/lib/adobe-auth.js#L24-L36

Note the sync can also be run on demand by running `npm run sync-oauth-credentials`

Output when running and there's no credentials at all
```shell
$ aio app build

2025-06-06T13:25:02.741Z [scripts/sync-oauth-credentials] info: Added OAUTH_CLIENT_ID with value from AIO_ims_contexts_Commerce__checkout__starter__kit__-__Stage_client__id
2025-06-06T13:25:02.741Z [scripts/sync-oauth-credentials] info: Added OAUTH_CLIENT_SECRETS with value from AIO_ims_contexts_Commerce__checkout__starter__kit__-__Stage_client__secrets
2025-06-06T13:25:02.742Z [scripts/sync-oauth-credentials] info: Added OAUTH_TECHNICAL_ACCOUNT_EMAIL with value from AIO_ims_contexts_Commerce__checkout__starter__kit__-__Stage_technical__account__email
2025-06-06T13:25:02.742Z [scripts/sync-oauth-credentials] info: Added OAUTH_TECHNICAL_ACCOUNT_ID with value from AIO_ims_contexts_Commerce__checkout__starter__kit__-__Stage_technical__account__id
2025-06-06T13:25:02.743Z [scripts/sync-oauth-credentials] info: Added OAUTH_SCOPES with value from AIO_ims_contexts_Commerce__checkout__starter__kit__-__Stage_scopes
2025-06-06T13:25:02.743Z [scripts/sync-oauth-credentials] info: Added OAUTH_IMS_ORG_ID with value from AIO_ims_contexts_Commerce__checkout__starter__kit__-__Stage_ims__org__id
2025-06-06T13:25:02.743Z [scripts/sync-oauth-credentials] info: OAUTH env vars synced successfully
2025-06-06T13:25:02.743Z [hooks/pre-app-build] info: Done
ℹ No actions built for 'application'
ℹ No frontend or a build already exists, skipping frontend build for 'application'
ℹ No actions built for 'commerce/backend-ui/1'
ℹ No frontend or a build already exists, skipping frontend build for 'commerce/backend-ui/1'

$
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
