### PR TITLE
INTERNAL: reorg .env parameters order

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -1,14 +1,8 @@
-# Option 1: Authenticate without IMS
-#COMMERCE_CONSUMER_KEY=
-#COMMERCE_CONSUMER_SECRET=
-#COMMERCE_ACCESS_TOKEN=
-#COMMERCE_ACCESS_TOKEN_SECRET=
-
-# Option 2: Authenticate with IMS
-# OAuth configs
-# The following values can be copied from the Credential details page in AppBuilder under Organization > Project > Workspace > OAuth Server-to-Server
 # To configure Commerce instance to allow this creds please follow https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/connect/
-# Note OAUTH_CLIENT_SECRETS and OAUTH_SCOPES should be arrays
+# Option 1: Authenticate with IMS
+# The OAuth configs can be copied from the Credential details page in AppBuilder under Organization > Project > Workspace > OAuth Server-to-Server
+# The IMS configurations should already be available in your .env file after running `aio app use --merge`, and
+# you can copy them. Note OAUTH_CLIENT_SECRETS and OAUTH_SCOPES should be arrays
 OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRETS=[""]
 OAUTH_TECHNICAL_ACCOUNT_ID=
@@ -16,8 +10,11 @@ OAUTH_TECHNICAL_ACCOUNT_EMAIL=
 OAUTH_SCOPES=[""]
 OAUTH_IMS_ORG_ID=
 
-# Contains the mapping of the event provider metadata and the provider id
-AIO_EVENTS_PROVIDERMETADATA_TO_PROVIDER_MAPPING=
+# Option 2: Authenticate with Commerce
+#COMMERCE_CONSUMER_KEY=
+#COMMERCE_CONSUMER_SECRET=
+#COMMERCE_ACCESS_TOKEN=
+#COMMERCE_ACCESS_TOKEN_SECRET=
 
 # Environment for AIO: stage or prod (default)
 #AIO_CLI_ENV=
@@ -28,13 +25,16 @@ AIO_EVENTS_PROVIDERMETADATA_TO_PROVIDER_MAPPING=
 # - Commerce Admin REST endpoints: https://{commerce_instance_url}/rest/{store_view_code}/
 # - Adobe Commerce Cloud as a Service: https://na1.api.commerce.adobe.com/{tenant_code}/
 COMMERCE_BASE_URL=
-# The payment method codes that this app is implementing, has to be in sync with the payment-methods.yaml file.
-COMMERCE_PAYMENT_METHOD_CODES=[""]
 # Required if webhooks are used and signature verification is enabled
 COMMERCE_WEBHOOKS_PUBLIC_KEY=
+# Contains the mapping of the event provider metadata and the provider id
+AIO_EVENTS_PROVIDERMETADATA_TO_PROVIDER_MAPPING=
 
 # Commerce Event Module configs
 # These values will be used to configure the Adobe I/O Events module automatically
 # that can be found at Stores > Configuration > Adobe Services > Adobe I/O Events > Commerce events
 COMMERCE_ADOBE_IO_EVENTS_MERCHANT_ID=
 COMMERCE_ADOBE_IO_EVENTS_ENVIRONMENT_ID=
+
+# The payment method codes that this app is implementing, has to be in sync with the payment-methods.yaml file.
+COMMERCE_PAYMENT_METHOD_CODES=[""]

--- a/env.dist
+++ b/env.dist
@@ -1,8 +1,7 @@
 # To configure Commerce instance to allow this creds please follow https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/connect/
 # Option 1: Authenticate with IMS
-# The OAuth configs can be copied from the Credential details page in AppBuilder under Organization > Project > Workspace > OAuth Server-to-Server
-# The IMS configurations should already be available in your .env file after running `aio app use --merge`, and
-# you can copy them. Note OAUTH_CLIENT_SECRETS and OAUTH_SCOPES should be arrays
+# The OAuth configs are available on the Credential Details page in AppBuilder under Organization > Project > Workspace > OAuth Server-to-Server.
+# These values are automatically populated from the AIO_ims_contexts_* variables in your .env file by the sync-oauth-credentials hook during the app build process.
 OAUTH_CLIENT_ID=
 OAUTH_CLIENT_SECRETS=[""]
 OAUTH_TECHNICAL_ACCOUNT_ID=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Place `Authenticate with IMS` first, which is same order as https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/connect/
- Minor improvements in tax calculation:
  - Should let the code assume `Apply Tax After Discount = NO`
  - Use logger name same as webhook action name
  - Use same body parsing code