### PR TITLE
CEXT-4810: fix Commerce URL is empty from scripts

### DIFF
--- a/lib/adobe-commerce.js
+++ b/lib/adobe-commerce.js
@@ -133,7 +133,7 @@ async function getAdobeCommerceClient(params) {
     ...(await resolveAuthOptions(params)),
   };
 
-  const commerceGot = await getCommerceHttpClient(params.COMMERCE_BASE_URL, options);
+  const commerceGot = await getCommerceHttpClient(params.COMMERCE_BASE_URL ?? process.env.COMMERCE_BASE_URL, options);
 
   const wrapper = async (callable) => {
     try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Revert a change in https://github.com/adobe/commerce-checkout-starter-kit/pull/34
- Fix commerce base url is empty from the scripts
```
params.COMMERCE_BASE_URL undefined
process.env.COMMERCE_BASE_URL https://na1-sandbox.api.commerce.adobe.com/JNjfhWJ3MJvZhj3bwsamRP/
/Users/sangmil/Project/eds/oope-party-parrots-demo/lib/adobe-commerce.js:32
    throw new Error('Commerce URL must be provided');
          ^
Error: Commerce URL must be provided
    at getCommerceHttpClient (/Users/sangmil/Project/eds/oope-party-parrots-demo/lib/adobe-commerce.js:32:11)
    at getAdobeCommerceClient (/Users/sangmil/Project/eds/oope-party-parrots-demo/lib/adobe-commerce.js:139:29)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Object.main (/Users/sangmil/Project/eds/oope-party-parrots-demo/scripts/create-tax-integrations.js:32:18)
```

