### PR TITLE
Fix Commerce integration auth failure when OAuth credentials exist

### DIFF
--- a/lib/adobe-auth.js
+++ b/lib/adobe-auth.js
@@ -54,25 +54,12 @@ async function resolveCredentials(params) {
 
 /**
  * Resolve the authentication options based on the provided parameters.
- * Note that IMS authentication is preferred over Commerce integration options.
+ * Note that Commerce integration options is preferred over IMS authentication options.
  * @param {object} params action input parameters.
  * @returns {Promise<{imsOptions: object}|{integrationOptions: object}>} returns the resolved authentication options
  * @throws {Error} if neither Commerce integration options nor IMS options are provided as params
  */
 async function resolveAuthOptions(params) {
-  if (
-    allNonEmpty(params, [
-      'OAUTH_CLIENT_ID',
-      'OAUTH_CLIENT_SECRETS',
-      'OAUTH_TECHNICAL_ACCOUNT_ID',
-      'OAUTH_TECHNICAL_ACCOUNT_EMAIL',
-      'OAUTH_IMS_ORG_ID',
-      'OAUTH_SCOPES',
-    ])
-  ) {
-    return { imsOptions: await resolveCredentials(params) };
-  }
-
   if (
     allNonEmpty(params, [
       'COMMERCE_CONSUMER_KEY',
@@ -89,6 +76,19 @@ async function resolveAuthOptions(params) {
         accessTokenSecret: params.COMMERCE_ACCESS_TOKEN_SECRET,
       },
     };
+  }
+
+  if (
+    allNonEmpty(params, [
+      'OAUTH_CLIENT_ID',
+      'OAUTH_CLIENT_SECRETS',
+      'OAUTH_TECHNICAL_ACCOUNT_ID',
+      'OAUTH_TECHNICAL_ACCOUNT_EMAIL',
+      'OAUTH_IMS_ORG_ID',
+      'OAUTH_SCOPES',
+    ])
+  ) {
+    return { imsOptions: await resolveCredentials(params) };
   }
 
   throw new Error(


### PR DESCRIPTION
## Description

- `OAUTH_*` credentials in `.env` are generally essential regardless of authentication type (commerce integrations/IMS), and the automation to sync these credentials has been added: https://developer.adobe.com/commerce/extensibility/starter-kit/checkout/configure/#configure-oauth-server-to-server-credential. In the case of IMS credentials, OAuth Server-to-server credential is used together.
- When these credentials exist, the latest change to support SaaS/PaaS altered the precedence to IMS authentication first, stored in `OAUTH_*`. As a result, PaaS users who synced their I/O Management API service couldn't proceed with authentication using Commerce integrations.
- This fix changed the precedence to check Commerce integrations first in the Adobe Commerce client.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
