### PR TITLE
CEXT-6067: add renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":automergeDisabled",
+    ":ignoreUnstable",
+    ":prConcurrentLimitNone",
+    ":preserveSemverRanges",
+    ":rebaseStalePrs",
+    ":renovatePrefix",
+    ":separateMultipleMajorReleases",
+    ":updateNotScheduled",
+    "config:best-practices",
+    "config:recommended",
+    "customManagers:biomeVersions",
+    "group:definitelyTyped",
+    "group:monorepos",
+    "group:recommended",
+    "helpers:disableTypesNodeMajor",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "security:minimumReleaseAgeNpm"
+  ],
+  "automerge": false,
+  "branchPrefix": "renovate/",
+  "commitMessagePrefix": "RENOVATE: ",
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "schedule": ["on Monday"]
+    },
+    {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true,
+      "schedule": ["on Monday"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.github/renovate.json` aligned with the config used in `aio-commerce-sdk`
- Enables automerge for non-major dependency updates and lock file maintenance on Mondays
- Uses `config:best-practices`, `config:recommended`, and `customManagers:biomeVersions`

## Test plan

- [ ] Verify Renovate picks up the new config after merge