### PR TITLE
group major aio-commerce-sdk updates in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,6 +36,12 @@
       "matchUpdateTypes": ["lockFileMaintenance"],
       "automerge": true,
       "schedule": ["on Monday"]
+    },
+    {
+      "groupName": "aio-commerce-sdk",
+      "matchPackageNames": ["@adobe/aio-commerce-lib-*", "@adobe/aio-commerce-sdk*"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Group major updates to `@adobe/aio-commerce-lib-*` and `@adobe/aio-commerce-sdk*` into a dedicated PR for coordinated review. Minor/patch updates remain in the automerged non-major group.