### PR TITLE
CEXT-6067: add vulnerability alerts to renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,11 @@
     ":separateMultipleMajorReleases"
   ],
   "automerge": false,
+  "vulnerabilityAlerts": {
+    "automerge": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "transitiveRemediation": true,
   "branchPrefix": "renovate/",
   "commitMessagePrefix": "RENOVATE: ",
   "labels": ["dependencies"],
@@ -39,7 +44,10 @@
     },
     {
       "groupName": "aio-commerce-sdk",
-      "matchPackageNames": ["@adobe/aio-commerce-lib-*", "@adobe/aio-commerce-sdk*"],
+      "matchPackageNames": [
+        "@adobe/aio-commerce-lib-*",
+        "@adobe/aio-commerce-sdk*"
+      ],
       "matchUpdateTypes": ["major"],
       "automerge": false
     }


### PR DESCRIPTION
## Summary

Adds automatic vulnerability detection and remediation to the Renovate config.

### New flags

- **`vulnerabilityAlerts.automerge: true`** — when Renovate detects a package with a known vulnerability (via npm audit), it creates an immediate PR to fix it, bypassing the regular Monday schedule. `automerge: true` means it will merge automatically once CI passes.
- **`osvVulnerabilityAlerts: true`** — broadens vulnerability detection by also querying the [OSV database](https://osv.dev/) (Open Source Vulnerabilities), which has wider coverage than npm audit alone.
- **`transitiveRemediation: true`** — extends fixes to transitive (indirect) dependencies by injecting `overrides` in `package.json`, not just direct deps.

> **Note:** PRs generated by these rules will only be merged if all CI checks pass.
