### PR TITLE
CEXT-6067: add vulnerability alerts to renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,11 @@
     ":separateMultipleMajorReleases"
   ],
   "automerge": false,
+  "vulnerabilityAlerts": {
+    "automerge": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "transitiveRemediation": true,
   "branchPrefix": "renovate/",
   "commitMessagePrefix": "RENOVATE: ",
   "labels": ["dependencies"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,6 @@
     "automerge": true
   },
   "osvVulnerabilityAlerts": true,
-  "transitiveRemediation": true,
   "branchPrefix": "renovate/",
   "commitMessagePrefix": "RENOVATE: ",
   "labels": ["dependencies"],


### PR DESCRIPTION
## Summary

Adds automatic vulnerability detection to the Renovate config.

### New flags

- **`vulnerabilityAlerts.automerge: true`** — when Renovate detects a package with a known vulnerability (via GitHub Dependabot alerts), it creates an immediate PR to fix it, bypassing the regular Monday schedule. `automerge: true` means it will merge automatically once CI passes.
- **`osvVulnerabilityAlerts: true`** — broadens vulnerability detection by also querying the [OSV database](https://osv.dev/) (Open Source Vulnerabilities), which has wider coverage than npm audit alone.

> **Note:** PRs generated by these rules will only be merged if all CI checks pass.

Mirrors the same change applied to `commerce-integration-starter-kit` in [adobe/commerce-integration-starter-kit#115](https://github.com/adobe/commerce-integration-starter-kit/pull/115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)