### PR TITLE
CEXT-6067: sync node version across .nvmrc and runtime actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,16 @@
   "commitMessagePrefix": "RENOVATE: ",
   "labels": ["dependencies"],
   "postUpdateOptions": ["npmDedupe"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/\\.config\\.yaml$/"],
+      "matchStrings": ["runtime: ['\"]?nodejs:(?<currentValue>\\d+)['\"]?"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    }
+  ],
   "packageRules": [
     {
       "groupName": "all non-major dependencies",
@@ -47,6 +57,12 @@
         "@adobe/aio-commerce-lib-*",
         "@adobe/aio-commerce-sdk*"
       ],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "groupName": "node version",
+      "matchPackageNames": ["node"],
       "matchUpdateTypes": ["major"],
       "automerge": false
     }

--- a/.github/workflows-samples/deploy_prod.yml
+++ b/.github/workflows-samples/deploy_prod.yml
@@ -10,15 +10,14 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: ['20']
         os: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
       - name: npm install
         run: npm i
       - name: Setup CLI

--- a/.github/workflows-samples/deploy_stage.yml
+++ b/.github/workflows-samples/deploy_stage.yml
@@ -11,15 +11,14 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: ['20']
         os: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
       - name: npm install
         run: npm i
       - name: Setup CLI

--- a/.github/workflows-samples/pr_test.yml
+++ b/.github/workflows-samples/pr_test.yml
@@ -7,15 +7,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: ['20']
         os: [macOS-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
       - name: npm install
         run: npm i
       - name: Setup CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,13 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node-version: [22.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
       - run: npm ci
       - run: npm run code:check

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sync-oauth-credentials": "node scripts/sync-oauth-credentials.js"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": "^22.0.0"
   },
   "lint-staged": {
     "*": [


### PR DESCRIPTION
## Summary

Ports the node version sync approach from [`commerce-integration-starter-kit#120`](https://github.com/adobe/commerce-integration-starter-kit/pull/120).

- **Renovate custom regex manager** — tracks `runtime: nodejs:XX` in all `*.config.yaml` files (unquoted in `app.config.yaml`, single-quoted in `commerce-backend-ui-1/ext.config.yaml`) using a single optional-quote pattern: `[\'"]?nodejs:(?<currentValue>\\d+)[\'"]?`
- **Node version grouping rule** — bundles all `node` major updates into one Renovate PR so `.nvmrc`, `package.json` engines, and all runtime actions bump together
- **`engines.node: ^22.0.0`** — replaces `>=22.0.0` which Renovate resolved to "latest node overall" and never proposed updates for
- **`node-version-file: '.nvmrc'`** — CI workflow and all sample workflows now read from `.nvmrc` directly; no separate tracking needed

## Result

After this PR, a single Renovate PR will update all of these when Node 24 is adopted:

| File | Change |
|---|---|
| `.nvmrc` | `22.x.x` → `24.x.x` |
| `package.json` engines | `^22.0.0` → `^24.0.0` |
| `app.config.yaml` (×19) | `nodejs:22` → `nodejs:24` |
| `ext.config.yaml` (×2) | `'nodejs:22'` → `'nodejs:24'` |
| `.github/workflows/ci.yml` | follows `.nvmrc` automatically |
| `.github/workflows-samples/*.yml` | follows `.nvmrc` automatically |

🤖 Generated with [Claude Code](https://claude.com/claude-code)