### PR TITLE
CEXT-6421: Fix workspace creation

### DIFF
--- a/.github/workflows/apps-pipeline.yml
+++ b/.github/workflows/apps-pipeline.yml
@@ -91,10 +91,10 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             number="${{ github.event.pull_request.number }}"
             raw="PR${number}${app_id}"
-            title="PR${number} ${app}"
+            title="PR${number} ${app_id}"
           else
             raw="main${app_id}"
-            title="Main ${app}"
+            title="Main ${app_id}"
           fi
           echo "name=${raw:0:20}" >> "$GITHUB_OUTPUT"
           echo "title=$title" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

Sanitize the workspace title in the App Builder pipeline so it only contains alphanumeric characters and spaces, using the already-sanitized app id instead of the raw app name.

## Related Issue

N/A

## Motivation and Context

The Adobe Console workspace title must only contain alphanumeric characters and spaces. When an app name contained a hyphen (e.g. `shipping-method`), workspace creation failed in CI with "Workspace title ... is invalid."

## How Has This Been Tested?

Verified the workspace name/title computation logic manually against the failing app name.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.