### PR TITLE
CEXT-6421: disable workspace API attachment in ci

### DIFF
--- a/.github/workflows/apps-pipeline.yml
+++ b/.github/workflows/apps-pipeline.yml
@@ -125,15 +125,22 @@ jobs:
             --name "$workspace" \
             --title "${{ steps.workspace.outputs.title }}"
 
-          codes="$(yq -r '[(.apis // [])[].code] | join(",")' install.yaml)"
-          if [ -n "$codes" ]; then
-            echo "Attaching services: $codes..."
-            aio console workspace api add \
-              --orgId "${{ vars.AIO_ORG_ID }}" \
-              --projectName "${{ steps.project.outputs.name }}" \
-              --workspaceName "$workspace" \
-              --service-code "$codes"
-          fi
+          # Disabled: the CI OAuth Server-to-Server technical account doesn't have
+          # the Console role needed to attach APIs to a workspace. Listing the org's
+          # private-API catalog 400s with "Missing scope for private API access",
+          # and creating a new OAuth S2S credential on a fresh workspace (required
+          # before any API can be attached) 401s with "does not have the correct
+          # role in this organization". Re-enable once the technical account has
+          # been granted the required role.
+          # codes="$(yq -r '[(.apis // [])[].code] | join(",")' install.yaml)"
+          # if [ -n "$codes" ]; then
+          #   echo "Attaching services: $codes..."
+          #   aio console workspace api add \
+          #     --orgId "${{ vars.AIO_ORG_ID }}" \
+          #     --projectName "${{ steps.project.outputs.name }}" \
+          #     --workspaceName "$workspace" \
+          #     --service-code "$codes"
+          # fi
 
       - name: Select workspace
         run: aio console workspace select "${{ steps.workspace.outputs.name }}"


### PR DESCRIPTION
## Description

Comments out the "Attaching services" step in the `Ensure App Builder workspace`
job of `.github/workflows/apps-pipeline.yml`, which calls `aio console workspace
api add` for any app that declares `apis:` in its `install.yaml`.

## Related Issue

N/A

## Motivation and Context

This step currently fails for any app declaring `apis:` in `install.yaml`
(currently `apps/shipping-method`), blocking the `deploy` job. Tracing the
failure down to the underlying Console SDK calls (bypassing the `aio` CLI)
showed two separate permission gaps on the CI's OAuth Server-to-Server
technical account, neither fixable by changing what's asked of the CLI:

- Listing the org's private-API catalog (needed to validate/attach a service
  code) 400s with `ERR_MSG_OPERATION_NOT_ALLOWED: Missing scope for private
  API access` — even when the lookup is scoped to a single known service code.
- Creating a new OAuth Server-to-Server credential on a freshly-created
  workspace (required before any API can be attached to it) 401s with
  `The user does not have the correct role in this organization to perform
  this operation`.

Both point to the technical account's Console role/entitlement rather than
anything in this repo's workflow logic. Disabling the step (rather than
removing it) unblocks workspace creation and deployment while we check
whether that role can be elevated internally; the step can be re-enabled
once it is.

## How Has This Been Tested?

Reproduced the failure by calling the underlying `@adobe/aio-lib-console` SDK
methods directly (`getServicesForOrg`, filtered and unfiltered, and
`subscribeCredentialToServices`) against the real PR-preview workspace the
CI job had created, using the same OAuth Server-to-Server credentials the
workflow uses. Confirmed both errors above occur independently of the `aio`
CLI, ruling out a CLI-level workaround.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.