### PR TITLE
CEXT-6421: Fix scopes format

### DIFF
--- a/scripts/prepare-workspace-config.js
+++ b/scripts/prepare-workspace-config.js
@@ -27,6 +27,16 @@ const REQUIRED_FIELDS = [
   "AIO_PROJECT_WORKSPACE_NAME",
 ];
 
+// Fields that need ::add-mask:: — the rest are non-secret identifiers.
+export const SECRET_FIELDS = [
+  "CLIENTID",
+  "CLIENTSECRET",
+  "TECHNICALACCOUNTID",
+  "TECHNICALACCOUNTEMAIL",
+  "IMSORGID",
+  "AIO_RUNTIME_AUTH",
+];
+
 /**
  * Builds the env var name a workspace's raw config is expected under, e.g.
  * `shipping-method` + `PR` -> `SHIPPING_METHOD_PR`.
@@ -49,6 +59,7 @@ export function resolveWorkspaceEnvVarName(app, purpose) {
 export function resolveWorkspaceConfig(env) {
   const { APP, PURPOSE } = env;
   const varName = resolveWorkspaceEnvVarName(APP, PURPOSE);
+  console.log(`Resolving workspace config from ${varName}`);
   const rawValue = env[varName];
 
   if (!rawValue) {
@@ -113,16 +124,35 @@ export function parseWorkspaceConfig(rawWorkspaceJson) {
   return config;
 }
 
+/**
+ * Serializes a single flattened config value into the string written to
+ * GITHUB_ENV.
+ *
+ * @param {string} key the config field name.
+ * @param {*} value the field's value.
+ * @returns {string} the serialized value.
+ */
+export function serialize(key, value) {
+  if (key === "SCOPES") {
+    // adobe/aio-apps-action's oauth_sts command validates SCOPES as a plain
+    // comma-separated string (no brackets/quotes), not JSON.
+    return Array.isArray(value) ? value.join(",") : value;
+  }
+  return Array.isArray(value) ? JSON.stringify(value) : value;
+}
+
 export async function main() {
   const rawWorkspaceJson = resolveWorkspaceConfig(process.env);
   const config = parseWorkspaceConfig(rawWorkspaceJson);
 
   const lines = Object.entries(config).map(([key, value]) => {
-    const serialized = Array.isArray(value) ? JSON.stringify(value) : value;
-    // GitHub only auto-masks the literal secret value (the whole raw
-    // workspace.json blob); these derived fields are new strings it has
-    // never seen, so each one needs its own mask or it can leak into logs.
-    console.log(`::add-mask::${serialized}`);
+    const serialized = serialize(key, value);
+    if (SECRET_FIELDS.includes(key)) {
+      // GitHub only auto-masks the literal secret value (the whole raw
+      // workspace.json blob); these derived fields are new strings it has
+      // never seen, so each one needs its own mask or it can leak into logs.
+      console.log(`::add-mask::${serialized}`);
+    }
     return `${key}=${serialized}`;
   });
   await fs.appendFile(process.env.GITHUB_ENV, `${lines.join("\n")}\n`);

--- a/test/scripts/prepare-workspace-config.test.js
+++ b/test/scripts/prepare-workspace-config.test.js
@@ -12,12 +12,14 @@ governing permissions and limitations under the License.
 
 import { readFileSync } from "node:fs";
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import {
   parseWorkspaceConfig,
   resolveWorkspaceConfig,
   resolveWorkspaceEnvVarName,
+  SECRET_FIELDS,
+  serialize,
 } from "../../scripts/prepare-workspace-config.js";
 
 const rawWorkspaceJson = JSON.parse(
@@ -153,5 +155,97 @@ describe("resolveWorkspaceConfig", () => {
         PAYMENT_METHOD_MAIN: "not json",
       }),
     ).toThrow(INVALID_JSON_ERROR);
+  });
+
+  test("logs the resolved env var name for audit purposes", () => {
+    const logSpy = vi.spyOn(console, "log");
+
+    resolveWorkspaceConfig({
+      APP: "shipping-method",
+      PURPOSE: "MAIN",
+      SHIPPING_METHOD_MAIN: JSON.stringify(rawWorkspaceJson),
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("SHIPPING_METHOD_MAIN"),
+    );
+
+    logSpy.mockRestore();
+  });
+
+  test("logs the resolved env var name even when resolution later fails", () => {
+    const logSpy = vi.spyOn(console, "log");
+
+    expect(() =>
+      resolveWorkspaceConfig({
+        APP: "totals-collector",
+        PURPOSE: "PR",
+        TOTALS_COLLECTOR_PR: "",
+      }),
+    ).toThrow(MISSING_SECRET_ERROR);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("TOTALS_COLLECTOR_PR"),
+    );
+
+    logSpy.mockRestore();
+  });
+});
+
+describe("serialize", () => {
+  const config = parseWorkspaceConfig(rawWorkspaceJson);
+
+  test("joins SCOPES into a plain comma-separated string, not JSON", () => {
+    expect(serialize("SCOPES", config.SCOPES)).toBe(
+      "AdobeID,openid,adobeio_api",
+    );
+  });
+
+  test("still JSON-serializes other array fields", () => {
+    expect(
+      serialize(
+        "AIO_PROJECT_WORKSPACE_DETAILS_SERVICES",
+        config.AIO_PROJECT_WORKSPACE_DETAILS_SERVICES,
+      ),
+    ).toBe(JSON.stringify(config.AIO_PROJECT_WORKSPACE_DETAILS_SERVICES));
+  });
+
+  test("passes non-array values through unchanged", () => {
+    expect(serialize("CLIENTID", config.CLIENTID)).toBe(config.CLIENTID);
+  });
+});
+
+describe("SECRET_FIELDS", () => {
+  test("marks only credential/auth fields as needing a mask", () => {
+    expect([...SECRET_FIELDS].sort()).toEqual(
+      [
+        "CLIENTID",
+        "CLIENTSECRET",
+        "TECHNICALACCOUNTID",
+        "TECHNICALACCOUNTEMAIL",
+        "IMSORGID",
+        "AIO_RUNTIME_AUTH",
+      ].sort(),
+    );
+  });
+
+  test("does not include project/workspace identifiers, SCOPES, or services", () => {
+    const config = parseWorkspaceConfig(rawWorkspaceJson);
+    const unmasked = Object.keys(config).filter(
+      (key) => !SECRET_FIELDS.includes(key),
+    );
+
+    expect(unmasked.sort()).toEqual(
+      [
+        "SCOPES",
+        "AIO_RUNTIME_NAMESPACE",
+        "AIO_PROJECT_ID",
+        "AIO_PROJECT_NAME",
+        "AIO_PROJECT_ORG_ID",
+        "AIO_PROJECT_WORKSPACE_ID",
+        "AIO_PROJECT_WORKSPACE_NAME",
+        "AIO_PROJECT_WORKSPACE_DETAILS_SERVICES",
+      ].sort(),
+    );
   });
 });


### PR DESCRIPTION
## Description

Fixes `scripts/prepare-workspace-config.js` so `SCOPES` is written as a plain comma-separated string instead of a JSON array, restricts `::add-mask::` to actual credential/auth fields instead of every flattened value, and adds audit logging of the resolved workspace config env var name.

## Related Issue

N/A

## Motivation and Context

CI run [29321814888](https://github.com/adobe/commerce-checkout-starter-kit/actions/runs/29321814888/job/87049966513) failed the deploy job's "Authenticate with OAuth Server-to-Server" step with:

```
[generateOAuthSTSAuthToken] Validation errors: [...] "message": "Invalid scopes format. Must be a comma separated list of scopes"
```

`parseWorkspaceConfig` kept `SCOPES` as an array, and the serialization step JSON-stringified every array field, so `SCOPES` was written to `GITHUB_ENV` as `["AdobeID","openid","adobeio_api"]` instead of `AdobeID,openid,adobeio_api`, which `adobe/aio-apps-action`'s `oauth_sts` command rejects — failing every deploy that reaches this step.

While fixing this, also:
- Scoped `::add-mask::` down to the fields that actually carry credential/auth material (`CLIENTID`, `CLIENTSECRET`, `TECHNICALACCOUNTID`, `TECHNICALACCOUNTEMAIL`, `IMSORGID`, `AIO_RUNTIME_AUTH`), instead of masking every flattened value including non-secret identifiers like `AIO_PROJECT_ID`/`AIO_PROJECT_ORG_ID`/`AIO_PROJECT_WORKSPACE_NAME` — masking those would silently break the workflow's own "Log deploy target" step, which already prints them in plaintext for debugging.
- Added audit logging in `resolveWorkspaceConfig` of which `AIO_<APP>_<PURPOSE>_WORKSPACE_CONFIG` secret env var was resolved for a given run, to help debug misconfigured/missing secrets without logging any secret values.

## How Has This Been Tested?

Added/updated unit tests in `test/scripts/prepare-workspace-config.test.js` covering: `SCOPES` serializing to a comma-separated string, other array fields still JSON-serializing, the exact set of fields marked as needing a mask, and the audit log call. Full suite (`npm test`) and `npx biome check` pass locally.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.