### PR TITLE
CEXT-6421: Run aio app build/deploy via shell instead of aio-apps-action

### DIFF
--- a/.github/workflows/apps-pipeline.yml
+++ b/.github/workflows/apps-pipeline.yml
@@ -107,17 +107,15 @@ jobs:
           IMSORGID: ${{ env.IMSORGID }}
           SCOPES: ${{ env.SCOPES }}
 
+      # adobe/aio-apps-action shells out with no cwd override, so it always
+      # runs from GITHUB_WORKSPACE regardless of this job's working-directory
+      # default (that default only applies to `run:` steps). Running `aio`
+      # directly here keeps build/deploy scoped to apps/${{ inputs.app }}.
       - name: Build
-        uses: adobe/aio-apps-action@6d7fdea67de9ef5ee3bf4c730aeaa5eaa7e2c533 # 4.1.0
-        with:
-          os: ubuntu-latest
-          command: build
+        run: aio app build
 
       - name: Deploy
-        uses: adobe/aio-apps-action@6d7fdea67de9ef5ee3bf4c730aeaa5eaa7e2c533 # 4.1.0
-        with:
-          os: ubuntu-latest
-          command: deploy
+        run: aio app deploy --no-build
 
       # The pr workspace is shared across every PR touching this app, so a
       # successful deploy here is a smoke test, not a lasting preview: undeploy


### PR DESCRIPTION
## Description

`Build` and `Deploy` steps in `apps-pipeline.yml` now call the `aio` CLI directly via `run:` instead of `uses: adobe/aio-apps-action`.

## Related Issue

CEXT-6421

## Motivation and Context

The shipping-method deploy job was failing in CI (https://github.com/adobe/commerce-checkout-starter-kit/actions/runs/29325247437/job/87060011488) with `Cannot find package '@adobe/aio-sdk'`. The `adobe/aio-apps-action` shells out with no `cwd` override, so it always runs from the repo root rather than `apps/<app>/`, since GitHub Actions' `defaults.run.working-directory` only applies to `run:` steps, not `uses:` steps. This caused the build to pick up the old root-level `hooks/pre-app-build.js` instead of the app's own config. The existing `Undeploy` step already used a plain `run:` step and worked correctly, confirming the mechanism; `Build` and `Deploy` now follow the same pattern.

## How Has This Been Tested?

Verified via code inspection of `adobe/aio-apps-action`'s bundled source (confirms it calls `exec.exec()` with no `cwd` option) and the failing job's logs (the `Undeploy` step, a `run:` step, correctly targeted `apps/shipping-method`, while `Build`, a `uses:` step, did not). This workflow requires AIO/IMS secrets, so end-to-end verification is CI-only — will confirm once this fix runs against PR #127 (branch `shipping`).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.