### PR TITLE
CEXT-6467: update to latest aio commerce sdk versions

### DIFF
--- a/apps/payment-method/package.json
+++ b/apps/payment-method/package.json
@@ -14,8 +14,8 @@
     "postinstall": "npx aio-commerce-lib-app hooks postinstall"
   },
   "dependencies": {
-    "@adobe/aio-commerce-lib-app": "1.8.0-beta-20260714082406",
-    "@adobe/aio-commerce-sdk": "1.4.0-beta-20260714082406",
+    "@adobe/aio-commerce-lib-app": "^1.8.0",
+    "@adobe/aio-commerce-sdk": "^1.4.0",
     "@adobe/aio-lib-telemetry": "^1.2.0"
   },
   "devDependencies": {

--- a/apps/payment-method/webpack-config.cjs
+++ b/apps/payment-method/webpack-config.cjs
@@ -1,0 +1,13 @@
+"use strict";
+
+// Webpack >= 5.109.0 defaults `experiments.typescript` to "auto", which
+// auto-enables on Node.js >= 22.6 and turns on tsconfig resolution for every
+// module — including node_modules packages whose published tsconfig.json
+// extends an uninstalled devDependency (e.g. @ljharb/tsconfig), breaking the
+// action build with spurious "Module not found" errors. Actions here are
+// plain JS, so opt out of the built-in TypeScript support entirely.
+module.exports = {
+  experiments: {
+    typescript: false,
+  },
+};

--- a/apps/payment-method/webpack-config.cjs
+++ b/apps/payment-method/webpack-config.cjs
@@ -1,11 +1,9 @@
 "use strict";
 
-// Webpack >= 5.109.0 defaults `experiments.typescript` to "auto", which
-// auto-enables on Node.js >= 22.6 and turns on tsconfig resolution for every
-// module — including node_modules packages whose published tsconfig.json
-// extends an uninstalled devDependency (e.g. @ljharb/tsconfig), breaking the
-// action build with spurious "Module not found" errors. Actions here are
-// plain JS, so opt out of the built-in TypeScript support entirely.
+// Webpack >= 5.109.0 enables TypeScript support by default: it tries to
+// resolve types via the tsconfig.json of every module it bundles, including
+// node_modules packages. Some of those ship a tsconfig.json extending an
+// uninstalled devDependency, which fails the build.
 module.exports = {
   experiments: {
     typescript: false,

--- a/apps/shipping-method/package.json
+++ b/apps/shipping-method/package.json
@@ -14,8 +14,8 @@
     "postinstall": "npx aio-commerce-lib-app hooks postinstall"
   },
   "dependencies": {
-    "@adobe/aio-commerce-lib-app": "1.8.0-beta-20260714082406",
-    "@adobe/aio-commerce-sdk": "1.4.0-beta-20260714082406",
+    "@adobe/aio-commerce-lib-app": "^1.8.0",
+    "@adobe/aio-commerce-sdk": "^1.4.0",
     "@adobe/aio-lib-telemetry": "^1.2.0"
   },
   "devDependencies": {

--- a/apps/shipping-method/webpack-config.cjs
+++ b/apps/shipping-method/webpack-config.cjs
@@ -1,0 +1,13 @@
+"use strict";
+
+// Webpack >= 5.109.0 defaults `experiments.typescript` to "auto", which
+// auto-enables on Node.js >= 22.6 and turns on tsconfig resolution for every
+// module — including node_modules packages whose published tsconfig.json
+// extends an uninstalled devDependency (e.g. @ljharb/tsconfig), breaking the
+// action build with spurious "Module not found" errors. Actions here are
+// plain JS, so opt out of the built-in TypeScript support entirely.
+module.exports = {
+  experiments: {
+    typescript: false,
+  },
+};

--- a/apps/shipping-method/webpack-config.cjs
+++ b/apps/shipping-method/webpack-config.cjs
@@ -1,11 +1,9 @@
 "use strict";
 
-// Webpack >= 5.109.0 defaults `experiments.typescript` to "auto", which
-// auto-enables on Node.js >= 22.6 and turns on tsconfig resolution for every
-// module — including node_modules packages whose published tsconfig.json
-// extends an uninstalled devDependency (e.g. @ljharb/tsconfig), breaking the
-// action build with spurious "Module not found" errors. Actions here are
-// plain JS, so opt out of the built-in TypeScript support entirely.
+// Webpack >= 5.109.0 enables TypeScript support by default: it tries to
+// resolve types via the tsconfig.json of every module it bundles, including
+// node_modules packages. Some of those ship a tsconfig.json extending an
+// uninstalled devDependency, which fails the build.
 module.exports = {
   experiments: {
     typescript: false,

--- a/apps/tax-integration/package.json
+++ b/apps/tax-integration/package.json
@@ -14,9 +14,9 @@
     "postinstall": "npx aio-commerce-lib-app hooks postinstall"
   },
   "dependencies": {
-    "@adobe/aio-commerce-lib-admin-ui": "0.2.0-beta-20260714082406",
-    "@adobe/aio-commerce-lib-app": "1.8.0-beta-20260714082406",
-    "@adobe/aio-commerce-sdk": "1.4.0-beta-20260714082406",
+    "@adobe/aio-commerce-lib-admin-ui": "^0.2.0",
+    "@adobe/aio-commerce-lib-app": "^1.8.0",
+    "@adobe/aio-commerce-sdk": "^1.4.0",
     "@adobe/aio-lib-telemetry": "^1.2.0",
     "@react-spectrum/s2": "^1.5.1",
     "react": "^19.2.7",

--- a/apps/tax-integration/src/commerce-backend-ui-2/web-src/src/app.tsx
+++ b/apps/tax-integration/src/commerce-backend-ui-2/web-src/src/app.tsx
@@ -5,9 +5,8 @@ import config from "#app.commerce.config";
 import { TaxClassesPage } from "#web/pages/tax-classes-page.tsx";
 
 createExtensionApp({
+  menu: <TaxClassesPage />,
   metadata: {
     extensionId: config.metadata.id,
   },
-
-  routes: [{ element: <TaxClassesPage />, index: true }],
 });

--- a/apps/tax-integration/src/commerce-backend-ui-2/web-src/src/hooks/use-commerce-proxy-action.ts
+++ b/apps/tax-integration/src/commerce-backend-ui-2/web-src/src/hooks/use-commerce-proxy-action.ts
@@ -11,12 +11,11 @@ const COMMERCE_PROXY_ACTION = "tax-integration-admin-ui/commerce-proxy-action";
  * credentials (from `useIms()`).
  */
 export function useCommerceProxyAction() {
-  const ims = useIms();
+  const { data, error } = useIms();
   const { getActionUrl } = useConfig();
 
-  const imsError = ims.error;
-  const imsToken = ims.error ? null : ims.data.imsToken;
-  const imsOrgId = ims.error ? null : ims.data.imsOrgId;
+  const imsToken = data?.imsToken;
+  const imsOrgId = data?.imsOrgId;
 
   return useCallback(
     async (
@@ -24,8 +23,8 @@ export function useCommerceProxyAction() {
       method: "GET" | "POST" = "GET",
       payload: Record<string, unknown> | null = null,
     ): Promise<unknown> => {
-      if (imsError) {
-        throw imsError;
+      if (error) {
+        throw error;
       }
 
       const actionUrl = getActionUrl(COMMERCE_PROXY_ACTION);
@@ -53,6 +52,6 @@ export function useCommerceProxyAction() {
 
       return response.json();
     },
-    [getActionUrl, imsError, imsOrgId, imsToken],
+    [error, getActionUrl, imsOrgId, imsToken],
   );
 }

--- a/apps/tax-integration/src/commerce-backend-ui-2/web-src/src/hooks/use-commerce-proxy-action.ts
+++ b/apps/tax-integration/src/commerce-backend-ui-2/web-src/src/hooks/use-commerce-proxy-action.ts
@@ -11,8 +11,12 @@ const COMMERCE_PROXY_ACTION = "tax-integration-admin-ui/commerce-proxy-action";
  * credentials (from `useIms()`).
  */
 export function useCommerceProxyAction() {
-  const { imsOrgId, imsToken } = useIms();
+  const ims = useIms();
   const { getActionUrl } = useConfig();
+
+  const imsError = ims.error;
+  const imsToken = ims.error ? null : ims.data.imsToken;
+  const imsOrgId = ims.error ? null : ims.data.imsOrgId;
 
   return useCallback(
     async (
@@ -20,6 +24,10 @@ export function useCommerceProxyAction() {
       method: "GET" | "POST" = "GET",
       payload: Record<string, unknown> | null = null,
     ): Promise<unknown> => {
+      if (imsError) {
+        throw imsError;
+      }
+
       const actionUrl = getActionUrl(COMMERCE_PROXY_ACTION);
 
       const response = await fetch(actionUrl, {
@@ -31,7 +39,7 @@ export function useCommerceProxyAction() {
         headers: {
           authorization: `Bearer ${imsToken}`,
           "Content-Type": "application/json",
-          "x-gw-ims-org-id": imsOrgId,
+          "x-gw-ims-org-id": `${imsOrgId}`,
         },
         method: "POST",
       });
@@ -45,6 +53,6 @@ export function useCommerceProxyAction() {
 
       return response.json();
     },
-    [getActionUrl, imsOrgId, imsToken],
+    [getActionUrl, imsError, imsOrgId, imsToken],
   );
 }

--- a/apps/tax-integration/src/commerce-backend-ui-2/web-src/src/hooks/use-commerce-proxy-action.ts
+++ b/apps/tax-integration/src/commerce-backend-ui-2/web-src/src/hooks/use-commerce-proxy-action.ts
@@ -23,8 +23,8 @@ export function useCommerceProxyAction() {
       method: "GET" | "POST" = "GET",
       payload: Record<string, unknown> | null = null,
     ): Promise<unknown> => {
-      if (error) {
-        throw error;
+      if (!(imsToken && imsOrgId)) {
+        throw error ?? new Error("IMS credentials are not available.");
       }
 
       const actionUrl = getActionUrl(COMMERCE_PROXY_ACTION);
@@ -38,7 +38,7 @@ export function useCommerceProxyAction() {
         headers: {
           authorization: `Bearer ${imsToken}`,
           "Content-Type": "application/json",
-          "x-gw-ims-org-id": `${imsOrgId}`,
+          "x-gw-ims-org-id": imsOrgId,
         },
         method: "POST",
       });

--- a/apps/tax-integration/test/admin-ui/use-commerce-proxy-action.test.js
+++ b/apps/tax-integration/test/admin-ui/use-commerce-proxy-action.test.js
@@ -23,8 +23,8 @@ const { useCommerceProxyAction } = await import(
 beforeEach(() => {
   vi.clearAllMocks();
   useIms.mockReturnValue({
-    imsOrgId: "test-org-id",
-    imsToken: "test-ims-token",
+    data: { imsOrgId: "test-org-id", imsToken: "test-ims-token" },
+    error: null,
   });
   global.fetch = vi.fn();
 });

--- a/apps/tax-integration/test/admin-ui/use-get-commerce-tax-classes.test.js
+++ b/apps/tax-integration/test/admin-ui/use-get-commerce-tax-classes.test.js
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("@adobe/aio-commerce-lib-admin-ui/web", () => ({
   useIms: vi.fn(() => ({
-    imsOrgId: "test-org-id",
-    imsToken: "test-ims-token",
+    data: { imsOrgId: "test-org-id", imsToken: "test-ims-token" },
+    error: null,
   })),
 }));
 vi.mock(

--- a/apps/tax-integration/test/admin-ui/use-upsert-commerce-tax-class.test.js
+++ b/apps/tax-integration/test/admin-ui/use-upsert-commerce-tax-class.test.js
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("@adobe/aio-commerce-lib-admin-ui/web", () => ({
   useIms: vi.fn(() => ({
-    imsOrgId: "test-org-id",
-    imsToken: "test-ims-token",
+    data: { imsOrgId: "test-org-id", imsToken: "test-ims-token" },
+    error: null,
   })),
 }));
 vi.mock(

--- a/apps/tax-integration/webpack-config.cjs
+++ b/apps/tax-integration/webpack-config.cjs
@@ -1,0 +1,13 @@
+"use strict";
+
+// Webpack >= 5.109.0 defaults `experiments.typescript` to "auto", which
+// auto-enables on Node.js >= 22.6 and turns on tsconfig resolution for every
+// module — including node_modules packages whose published tsconfig.json
+// extends an uninstalled devDependency (e.g. @ljharb/tsconfig), breaking the
+// action build with spurious "Module not found" errors. Actions here are
+// plain JS, so opt out of the built-in TypeScript support entirely.
+module.exports = {
+  experiments: {
+    typescript: false,
+  },
+};

--- a/apps/tax-integration/webpack-config.cjs
+++ b/apps/tax-integration/webpack-config.cjs
@@ -1,11 +1,9 @@
 "use strict";
 
-// Webpack >= 5.109.0 defaults `experiments.typescript` to "auto", which
-// auto-enables on Node.js >= 22.6 and turns on tsconfig resolution for every
-// module — including node_modules packages whose published tsconfig.json
-// extends an uninstalled devDependency (e.g. @ljharb/tsconfig), breaking the
-// action build with spurious "Module not found" errors. Actions here are
-// plain JS, so opt out of the built-in TypeScript support entirely.
+// Webpack >= 5.109.0 enables TypeScript support by default: it tries to
+// resolve types via the tsconfig.json of every module it bundles, including
+// node_modules packages. Some of those ship a tsconfig.json extending an
+// uninstalled devDependency, which fails the build.
 module.exports = {
   experiments: {
     typescript: false,

--- a/apps/totals-collector/package.json
+++ b/apps/totals-collector/package.json
@@ -14,8 +14,8 @@
     "postinstall": "npx aio-commerce-lib-app hooks postinstall"
   },
   "dependencies": {
-    "@adobe/aio-commerce-lib-app": "1.8.0-beta-20260714082406",
-    "@adobe/aio-commerce-sdk": "1.4.0-beta-20260714082406",
+    "@adobe/aio-commerce-lib-app": "^1.8.0",
+    "@adobe/aio-commerce-sdk": "^1.4.0",
     "@adobe/aio-lib-telemetry": "^1.2.0"
   },
   "devDependencies": {

--- a/apps/totals-collector/webpack-config.cjs
+++ b/apps/totals-collector/webpack-config.cjs
@@ -1,0 +1,13 @@
+"use strict";
+
+// Webpack >= 5.109.0 defaults `experiments.typescript` to "auto", which
+// auto-enables on Node.js >= 22.6 and turns on tsconfig resolution for every
+// module — including node_modules packages whose published tsconfig.json
+// extends an uninstalled devDependency (e.g. @ljharb/tsconfig), breaking the
+// action build with spurious "Module not found" errors. Actions here are
+// plain JS, so opt out of the built-in TypeScript support entirely.
+module.exports = {
+  experiments: {
+    typescript: false,
+  },
+};

--- a/apps/totals-collector/webpack-config.cjs
+++ b/apps/totals-collector/webpack-config.cjs
@@ -1,11 +1,9 @@
 "use strict";
 
-// Webpack >= 5.109.0 defaults `experiments.typescript` to "auto", which
-// auto-enables on Node.js >= 22.6 and turns on tsconfig resolution for every
-// module — including node_modules packages whose published tsconfig.json
-// extends an uninstalled devDependency (e.g. @ljharb/tsconfig), breaking the
-// action build with spurious "Module not found" errors. Actions here are
-// plain JS, so opt out of the built-in TypeScript support entirely.
+// Webpack >= 5.109.0 enables TypeScript support by default: it tries to
+// resolve types via the tsconfig.json of every module it bundles, including
+// node_modules packages. Some of those ship a tsconfig.json extending an
+// uninstalled devDependency, which fails the build.
 module.exports = {
   experiments: {
     typescript: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "scripts"
       ],
       "devDependencies": {
+        "@ljharb/tsconfig": "^0.3.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.0"
       },
@@ -2359,6 +2360,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@ljharb/tsconfig": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@ljharb/tsconfig/-/tsconfig-0.3.2.tgz",
+      "integrity": "sha512-eAl8JEVuTikzBOgymq/ndBPOH5hThMLlryKoH3O4evzNHO9VfxKF6f81gxWyCadO6zKKkXO0IVOh+nvYB0aTZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@adobe/aio-commerce-lib-app": "1.8.0-beta-20260714082406",
-        "@adobe/aio-commerce-sdk": "1.4.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-app": "^1.8.0",
+        "@adobe/aio-commerce-sdk": "^1.4.0",
         "@adobe/aio-lib-telemetry": "^1.2.0"
       },
       "devDependencies": {
@@ -43,8 +43,8 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@adobe/aio-commerce-lib-app": "1.8.0-beta-20260714082406",
-        "@adobe/aio-commerce-sdk": "1.4.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-app": "^1.8.0",
+        "@adobe/aio-commerce-sdk": "^1.4.0",
         "@adobe/aio-lib-telemetry": "^1.2.0"
       },
       "devDependencies": {
@@ -62,9 +62,9 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@adobe/aio-commerce-lib-admin-ui": "0.2.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-app": "1.8.0-beta-20260714082406",
-        "@adobe/aio-commerce-sdk": "1.4.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-admin-ui": "^0.2.0",
+        "@adobe/aio-commerce-lib-app": "^1.8.0",
+        "@adobe/aio-commerce-sdk": "^1.4.0",
         "@adobe/aio-lib-telemetry": "^1.2.0",
         "@react-spectrum/s2": "^1.5.1",
         "react": "^19.2.7",
@@ -91,8 +91,8 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@adobe/aio-commerce-lib-app": "1.8.0-beta-20260714082406",
-        "@adobe/aio-commerce-sdk": "1.4.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-app": "^1.8.0",
+        "@adobe/aio-commerce-sdk": "^1.4.0",
         "@adobe/aio-lib-telemetry": "^1.2.0"
       },
       "devDependencies": {
@@ -106,13 +106,13 @@
       }
     },
     "node_modules/@adobe/aio-commerce-lib-admin-ui": {
-      "version": "0.2.0-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-admin-ui/-/aio-commerce-lib-admin-ui-0.2.0-beta-20260714082406.tgz",
-      "integrity": "sha512-+oINIugVuiYo2V+tnHBL2vYwrpwAx8ndMeTmiCpZKRNG70JfNwn5pVJALeSP7mwx4nulhpCmhNVyrLFqIMS2zw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-admin-ui/-/aio-commerce-lib-admin-ui-0.2.0.tgz",
+      "integrity": "sha512-uRWTxzRRUeMsT3Sb+OQBG3z1Lexkn0AebLcgpE1upD4koObafIhfqbu+p93wilRXJ+7ktP+Z0UHnrP54nKAPXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/aio-commerce-lib-api": "1.3.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-core": "1.2.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-api": "1.3.0",
+        "@adobe/aio-commerce-lib-core": "1.2.0",
         "@adobe/exc-app": "^1.4.20",
         "@adobe/uix-guest": "^1.0.3",
         "@tanstack/react-router": "^1.170.15",
@@ -141,13 +141,13 @@
       }
     },
     "node_modules/@adobe/aio-commerce-lib-api": {
-      "version": "1.3.0-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-api/-/aio-commerce-lib-api-1.3.0-beta-20260714082406.tgz",
-      "integrity": "sha512-QT8VrdUI0xRP8+8cvFeUJb41JWsxueXpv21QU1zgUnvuoxCe6KCENCrfSDyiZilJ6yhRgBs9xgIQ9xjeIV8XIw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-api/-/aio-commerce-lib-api-1.3.0.tgz",
+      "integrity": "sha512-RTxAXbCYPpbkg8wKYWbXG5c9NL02d82lQorcE7546vcaS9uFOpt+aFgXMIClzgyq6vkSvvUdgj2PglrQZXLwJw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/aio-commerce-lib-auth": "1.1.2-beta-20260714082406",
-        "@adobe/aio-commerce-lib-core": "1.2.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-auth": "1.1.2",
+        "@adobe/aio-commerce-lib-core": "1.2.0",
         "camelcase": "^9.0.0",
         "ky": "^1.9.0",
         "type-fest": "^5.0.0"
@@ -157,18 +157,18 @@
       }
     },
     "node_modules/@adobe/aio-commerce-lib-app": {
-      "version": "1.8.0-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-app/-/aio-commerce-lib-app-1.8.0-beta-20260714082406.tgz",
-      "integrity": "sha512-+7njfBAnawX8w3HXBxcN2QDUzbtV446G267eb7tN1P/+EuLUohXGkVsAwds07MY+mnNWgtfFsyolGpCX/ruepQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-app/-/aio-commerce-lib-app-1.8.0.tgz",
+      "integrity": "sha512-gfY0zqXbi+HsJRj9Dsw8PkipSXbc/VVERks/OyMhJLCLrs05KNlDJpDdJiNohUIeCni7ziVCNz0ZS6SIombcXw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/aio-commerce-lib-admin-ui": "0.2.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-api": "1.3.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-auth": "1.1.2-beta-20260714082406",
-        "@adobe/aio-commerce-lib-config": "1.6.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-core": "1.2.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-events": "1.3.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-webhooks": "1.2.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-admin-ui": "0.2.0",
+        "@adobe/aio-commerce-lib-api": "1.3.0",
+        "@adobe/aio-commerce-lib-auth": "1.1.2",
+        "@adobe/aio-commerce-lib-config": "1.6.0",
+        "@adobe/aio-commerce-lib-core": "1.2.0",
+        "@adobe/aio-commerce-lib-events": "1.3.0",
+        "@adobe/aio-commerce-lib-webhooks": "1.2.0",
         "@adobe/aio-lib-core-config": "^5.0.1",
         "@adobe/aio-lib-core-logging": "^3.0.2",
         "@adobe/aio-lib-files": "^4.1.2",
@@ -201,12 +201,12 @@
       }
     },
     "node_modules/@adobe/aio-commerce-lib-auth": {
-      "version": "1.1.2-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-auth/-/aio-commerce-lib-auth-1.1.2-beta-20260714082406.tgz",
-      "integrity": "sha512-5ZxHJD2nrFYycZnbfmoWZ1brHiJk+CZ3YuN8UH7Fc2wb9CuR1HDqSfJQkfsvzE9kmwEllrrdYsQGXmzIbkoQAg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-auth/-/aio-commerce-lib-auth-1.1.2.tgz",
+      "integrity": "sha512-u1VmHEwKIJkjMPLFR4GZ/+bDPEWwkaFwjN6maJzpCVhRqmYlh/z7M7CkNRQ9gl5pSBoYof8FrDlQLeLJXoPp+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/aio-commerce-lib-core": "1.2.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-core": "1.2.0",
         "@adobe/aio-lib-core-config": "^5.0.1",
         "@adobe/aio-lib-ims": "^8.1.1",
         "ansis": "^4.1.0",
@@ -224,13 +224,13 @@
       }
     },
     "node_modules/@adobe/aio-commerce-lib-config": {
-      "version": "1.6.0-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-config/-/aio-commerce-lib-config-1.6.0-beta-20260714082406.tgz",
-      "integrity": "sha512-sesNTZaso/Wrj8kk70P/8/z7GW6Af7RE/4nCTU7wtBqV129kHMLYNoSaGIzOYGFiW1T8J6LPqbhiGPV1oTKfMA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-config/-/aio-commerce-lib-config-1.6.0.tgz",
+      "integrity": "sha512-Nucfn74MYRUtnh8i8qluCVmCXUu9ZR0lh8u4L5mD5U9rkyaOB6t+7rmWHV/kjyImjFgA9S2pVM5w+FHC5agMXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/aio-commerce-lib-api": "1.3.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-core": "1.2.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-api": "1.3.0",
+        "@adobe/aio-commerce-lib-core": "1.2.0",
         "@adobe/aio-lib-core-config": "^5.0.1",
         "@adobe/aio-lib-core-logging": "^3.0.2",
         "@adobe/aio-lib-files": "^4.1.2",
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/@adobe/aio-commerce-lib-core": {
-      "version": "1.2.0-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-core/-/aio-commerce-lib-core-1.2.0-beta-20260714082406.tgz",
-      "integrity": "sha512-Rltwy1bMkvDX+e+wvv9ntirOcp8EOyJX/8jgDeIe/3MY+OrvuYSCY+EyLcaanXVB3HKNrQESHoawGUZ+MKMqAQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-core/-/aio-commerce-lib-core-1.2.0.tgz",
+      "integrity": "sha512-C6+UL6ROqXhy9+YKaRseshT7Jxu1gT1pM+5vekXbmBucUmnzfzjdPYVM75JFtOgb/Ke+ZOTwt7zpTdFS4/41ig==",
       "license": "Apache-2.0",
       "dependencies": {
         "ansis": "^4.1.0",
@@ -270,14 +270,14 @@
       }
     },
     "node_modules/@adobe/aio-commerce-lib-events": {
-      "version": "1.3.0-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-events/-/aio-commerce-lib-events-1.3.0-beta-20260714082406.tgz",
-      "integrity": "sha512-O+9/6O7M3q4gwQe73mpHD7bSZjLCXu8Aanv7Wy++lCYKFzQb/gXIF63+MklnjgEQdQT+l/JN80oUQvHObus7gg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-events/-/aio-commerce-lib-events-1.3.0.tgz",
+      "integrity": "sha512-Q+AETrgLfUMGJkRsAPGMw0hICzMT41x6KT/HdSrWh7/x6UAZzKXFEkR5suE7QuHvnln+6BsxpmM+718giATOMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/aio-commerce-lib-api": "1.3.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-auth": "1.1.2-beta-20260714082406",
-        "@adobe/aio-commerce-lib-core": "1.2.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-api": "1.3.0",
+        "@adobe/aio-commerce-lib-auth": "1.1.2",
+        "@adobe/aio-commerce-lib-core": "1.2.0",
         "ky": "^1.9.0",
         "type-fest": "^5.0.0",
         "valibot": "^1.1.0"
@@ -287,13 +287,13 @@
       }
     },
     "node_modules/@adobe/aio-commerce-lib-webhooks": {
-      "version": "1.2.0-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-webhooks/-/aio-commerce-lib-webhooks-1.2.0-beta-20260714082406.tgz",
-      "integrity": "sha512-2ZdrgcsOu8tFL1Uv4+mRQ0Pn5MglllMp0fQfLij2w/53rJCljVFHdHW77iuR+5B7uCWgkGAy8J8IoxTkIhhu0g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-lib-webhooks/-/aio-commerce-lib-webhooks-1.2.0.tgz",
+      "integrity": "sha512-0leCOO6BZA+vZ1GuXMkCDK6JF+JMBcMgAlRAJaR1jlwu2M1wTHZSXyPLlNWyYFn0TgLui7Xx0W/doO2S0qX1tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/aio-commerce-lib-api": "1.3.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-core": "1.2.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-api": "1.3.0",
+        "@adobe/aio-commerce-lib-core": "1.2.0",
         "ky": "^1.9.0",
         "valibot": "^1.1.0"
       },
@@ -302,17 +302,17 @@
       }
     },
     "node_modules/@adobe/aio-commerce-sdk": {
-      "version": "1.4.0-beta-20260714082406",
-      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-sdk/-/aio-commerce-sdk-1.4.0-beta-20260714082406.tgz",
-      "integrity": "sha512-hZjlJdM8MX4tHGnIMhzEHRXKY848MDnuoZlZKfZyX4tQlK2wosWBL3/WzsD50QbB89PbmBHfaqUjEw6F/9oqZQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@adobe/aio-commerce-sdk/-/aio-commerce-sdk-1.4.0.tgz",
+      "integrity": "sha512-o5wd8F2zX8aR1ftgcMyVDANhON1GtXLtgeGIfdpCORPl/qMUTi619pUOFwTZGBDTV19NW2iLEXC5BgQ/e7u7Og==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/aio-commerce-lib-admin-ui": "0.2.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-api": "1.3.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-auth": "1.1.2-beta-20260714082406",
-        "@adobe/aio-commerce-lib-core": "1.2.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-events": "1.3.0-beta-20260714082406",
-        "@adobe/aio-commerce-lib-webhooks": "1.2.0-beta-20260714082406",
+        "@adobe/aio-commerce-lib-admin-ui": "0.2.0",
+        "@adobe/aio-commerce-lib-api": "1.3.0",
+        "@adobe/aio-commerce-lib-auth": "1.1.2",
+        "@adobe/aio-commerce-lib-core": "1.2.0",
+        "@adobe/aio-commerce-lib-events": "1.3.0",
+        "@adobe/aio-commerce-lib-webhooks": "1.2.0",
         "type-fest": "^5.0.0"
       },
       "engines": {
@@ -658,18 +658,18 @@
       }
     },
     "node_modules/@adobe/uix-core": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@adobe/uix-core/-/uix-core-1.1.9.tgz",
-      "integrity": "sha512-IzIjyA//AhNj2VEBjvDQ8ya0G/ktFp/Se6V5m2QwPlcAvO4+9Reyuzt1c8yO9f9giRoHmj1jZMkkC6/E1/4H7g==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@adobe/uix-core/-/uix-core-1.1.10.tgz",
+      "integrity": "sha512-8EiLULgKtxYOmjiZwar/k6/0LZAtcVIzNWslYMUdv3/yW89KW210mRpsoPVFB/WKavhrs7wiGYnrHqamMqaoaA==",
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/uix-guest": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@adobe/uix-guest/-/uix-guest-1.1.9.tgz",
-      "integrity": "sha512-pmj7V40qclicWgmtKsPh0qhRA29zU3JVEabyB3fJGlGoDehDxS/XndLUbwFZ2WneMxAPnru6xg6y6qeYOOhckA==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@adobe/uix-guest/-/uix-guest-1.1.10.tgz",
+      "integrity": "sha512-RqKZdQwK2dpBdn2ZIvWlRAn4ALD+bO0k62Extgy0DzNZmcSl/vcKde9ygLux66b7a6nD/5PYy7GVsFRV8OV6fQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/uix-core": "^1.1.9",
+        "@adobe/uix-core": "^1.1.10",
         "ajv": "^8.12.0",
         "js-yaml": "^4.1.0"
       }
@@ -8483,9 +8483,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
-      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
     },
     "node_modules/parse5": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "scripts"
       ],
       "devDependencies": {
-        "@ljharb/tsconfig": "^0.3.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.0"
       },
@@ -2360,16 +2359,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
-      }
-    },
-    "node_modules/@ljharb/tsconfig": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@ljharb/tsconfig/-/tsconfig-0.3.2.tgz",
-      "integrity": "sha512-eAl8JEVuTikzBOgymq/ndBPOH5hThMLlryKoH3O4evzNHO9VfxKF6f81gxWyCadO6zKKkXO0IVOh+nvYB0aTZQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "devDependencies": {
+    "@ljharb/tsconfig": "^0.3.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "private": true,
   "devDependencies": {
-    "@ljharb/tsconfig": "^0.3.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.0"
   },


### PR DESCRIPTION
## Description

Update `@adobe/aio-commerce-sdk`, `@adobe/aio-commerce-lib-app`, and (in `tax-integration`) `@adobe/aio-commerce-lib-admin-ui` from beta-pinned versions to their latest stable releases (`^1.4.0`, `^1.8.0`, and `^0.2.0` respectively) across all four apps, and rebuild `package-lock.json`.

The stable `aio-commerce-lib-admin-ui` release changed two APIs used by the `tax-integration` admin UI: `createExtensionApp`'s default-page routing moved from a `routes[].index` flag to a dedicated `menu` prop, and `useIms()` now returns a `Result` discriminated union instead of flat `imsOrgId`/`imsToken` properties. Updated `app.tsx` and `useCommerceProxyAction` accordingly, and updated the tests that mocked the old `useIms()` shape.

## Related Issue

CEXT-6467

## Motivation and Context

The apps were pinned to dated beta builds of the aio commerce packages. Stable releases are now available and should be used instead.

## How Has This Been Tested?

Ran `npm run code:check` and `npm test` across all workspaces, `tsc --noEmit` in `tax-integration`'s admin UI, and `aio app build` in each of the four apps individually — all pass.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.